### PR TITLE
feat: add cnncecp.com to direct.txt

### DIFF
--- a/resouces/direct.txt
+++ b/resouces/direct.txt
@@ -1,0 +1,1 @@
+cnncecp.com


### PR DESCRIPTION
cnncecp.com 是中国核工业集团有限公司的域名，现在不在 cn 规则中，而这个域名似乎又不对境外开放，必须配置到直连规则中。